### PR TITLE
Update to Maven 3.9.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 /.idea/
 /*.iml
+/.vscode/

--- a/release-notes-1.4.0.md
+++ b/release-notes-1.4.0.md
@@ -4,5 +4,6 @@
 ${version-number}
 
 #### New Features
+- Updated Maven to version [3.9.2](https://maven.apache.org/docs/3.9.2/release-notes.html)
 
 #### Known Issues

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -40,8 +40,8 @@ RUN zypper -n refresh && \
     echo 6e29de1b58e17a54465d07eaa18bbde60b774bd17b1d7efcd2bc8dbbaf91c62abe8acb3933c5c27e630dc3b118453d2d0ab7fb206cf403e204708555bb0a6059 \
          /usr/share/maven/ref/settings-docker.xml | sha512sum -c - && \
     mkdir -p /usr/share/maven /usr/share/maven/ref && \
-    curl -fsSL -o /tmp/apache-maven.tar.gz https://apache.osuosl.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz && \
-    echo 332088670d14fa9ff346e6858ca0acca304666596fec86eea89253bd496d3c90deae2be5091be199f48e09d46cec817c6419d5161fb4ee37871503f472765d00 \
+    curl -fsSL -o /tmp/apache-maven.tar.gz https://apache.osuosl.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz && \
+    echo 900bdeeeae550d2d2b3920fe0e00e41b0069f32c019d566465015bdd1b3866395cbe016e22d95d25d51d3a5e614af2c83ec9b282d73309f644859bbad08b63db \
          /tmp/apache-maven.tar.gz | sha512sum -c - && \
     tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 && \
     rm -f /tmp/apache-maven.tar.gz && \

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -20,7 +20,7 @@ ARG DOCKER_HUB_PUBLIC=docker.io
 #
 # Public maven image that contains the mvn-entrypoint.sh and settings-docker.xml files required
 #
-FROM ${DOCKER_HUB_PUBLIC}/library/maven:3.8.6-jdk-11 AS public_maven
+FROM ${DOCKER_HUB_PUBLIC}/library/maven:3.9.2-eclipse-temurin-11 AS public_maven
 
 #
 # The actual image definition


### PR DESCRIPTION
## Overview

This change brings the Java 11 build env up to Maven 3.9.2.

## Source change summary

- Update Dockerfile with new Maven version and sha value.
- Ignore vscode folder
- Update release notes

## Reference links

- [Maven v3.9.2](https://maven.apache.org/docs/3.9.2/release-notes.html)